### PR TITLE
Correct highlighting for escape strings.

### DIFF
--- a/syntaxes/Spacebars.tmLanguage.json
+++ b/syntaxes/Spacebars.tmLanguage.json
@@ -407,7 +407,7 @@
     },
     "string-single-quoted": {
       "begin": "'",
-      "end": "'",
+      "end": "(?<!\\\\)(\\\\\\\\)*'",
       "name": "string.quoted.single.spacebars",
       "endCaptures": {
         "0": {


### PR DESCRIPTION
Certain common cases cause the string highlighting to break down, e.g.
```
{{>tooltip text='This button resets the user\'s view'}}
```